### PR TITLE
documentation: update readme terminal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ We are making use of [GitPkg](https://gitpkg.vercel.app/guide/) to make importin
 
 ```sh
 # Client code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-client?main
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-client?main'
 # Server code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?main
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?main'
 ```
 
 **Note**: The drawback of this approach is that just running a `yarn upgrade` doesn't seem to work reliably.
 
 The best workaround to this is to use a commit ref instead of `main` in the above. For example:
 
-```
+```sh
 # Client code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-client?1bc811bb8993db7a8e75409cdd004500ebaba3d5
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-client?1bc811bb8993db7a8e75409cdd004500ebaba3d5'
 # Server code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?74e88ad500a734ce797df3ed3e2a85bdacb71980
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?74e88ad500a734ce797df3ed3e2a85bdacb71980'
 ```
 
 Its worth noting that just because they are the same repo you do not need to use the same commit for each components,

--- a/blaise-login-react-client/README.md
+++ b/blaise-login-react-client/README.md
@@ -6,16 +6,16 @@ We are making use of [GitPkg](https://gitpkg.vercel.app/guide/) to make importin
 
 ```sh
 # Server code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?main
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?main'
 ```
 
 **Note**: The drawback of this approach is that just running a `yarn upgrade` doesn't seem to work reliably.
 
 The best workaround to this is to use a commit ref instead of `main` in the above. For example:
 
-```
+```sh
 # Server code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?74e88ad500a734ce797df3ed3e2a85bdacb71980
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?74e88ad500a734ce797df3ed3e2a85bdacb71980'
 ```
 
 Its worth noting that just because they are the same repo you do not need to use the same commit for each components,
@@ -109,7 +109,7 @@ function App(): ReactElement {
 export default App;
 ```
 
-If you need need to access API endpoints that are secured by `blaise-login-react-server` then you can use:
+If you need to access API endpoints that are secured by `blaise-login-react-server` then you can use:
 
 ```ts
 import { AuthManager } from "blaise-login-react-client";

--- a/blaise-login-react-server/README.md
+++ b/blaise-login-react-server/README.md
@@ -6,16 +6,16 @@ We are making use of [GitPkg](https://gitpkg.vercel.app/guide/) to make importin
 
 ```sh
 # Server code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?main
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?main'
 ```
 
 **Note**: The drawback of this approach is that just running a `yarn upgrade` doesn't seem to work reliably.
 
 The best workaround to this is to use a commit ref instead of `main` in the above. For example:
 
-```
+```sh
 # Server code
-yarn add https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?74e88ad500a734ce797df3ed3e2a85bdacb71980
+yarn add 'https://gitpkg.now.sh/ONSdigital/blaise-login-react/blaise-login-react-server?74e88ad500a734ce797df3ed3e2a85bdacb71980'
 ```
 
 Its worth noting that just because they are the same repo you do not need to use the same commit for each components,


### PR DESCRIPTION
add '' at the start and end of the .sh commands. Tested and this works on windows, however, as it is now copy and paste does not work on mac.

Reviewed-by: James & Jamie